### PR TITLE
license: use official plain text file of the LGPLv3 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,4 @@
-For copyright information, please see the COPYRIGHT file.
-
-
-**************************************************************************
-
-
-                 GNU LESSER GENERAL PUBLIC LICENSE
+                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>


### PR DESCRIPTION
Taken from the official fsf website at
https://www.gnu.org/licenses/lgpl-3.0.txt

The extra sentence that was present before this change would prevent Github from being able to parse the license file.